### PR TITLE
fix y_onehot

### DIFF
--- a/functions/preprocessing.py
+++ b/functions/preprocessing.py
@@ -282,7 +282,7 @@ def memsplit(matin, memchoose):
 
 
 def y_onehot(Yin, ltercile, utercile):
-    Yout = np.empty(len(Yin))
+    Yout = np.zeros(len(Yin))
 
     Yout[Yin < ltercile] = 0
     Yout[(Yin >= ltercile) & (Yin < utercile)] = 1


### PR DESCRIPTION
use [np.zeros] instead of [np.empty], in order to avoid an issue of index out of boundary (e.g., IndexError: index -2147483648 is out of bounds for axis 1 with size 10) when calling [to_categorical] function.